### PR TITLE
Use MonadPar to step two fused coroutines in parallel

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,10 @@
   },
   "dependencies": {
     "purescript-freet": "^1.0.0",
-    "purescript-profunctor": "^1.0.0"
+    "purescript-profunctor": "^1.0.0",
+    "purescript-parallel": "^1.0.0"
+  },
+  "devDependencies": {
+    "purescript-aff": "^1.0.0"
   }
 }

--- a/docs/Control/Coroutine.md
+++ b/docs/Control/Coroutine.md
@@ -41,7 +41,7 @@ Run a `Process` to completion.
 #### `fuseWith`
 
 ``` purescript
-fuseWith :: forall f g h m a. (Functor f, Functor g, Functor h, MonadRec m) => (forall d. forall b c. (b -> c -> d) -> f b -> g c -> h d) -> Co f m a -> Co g m a -> Co h m a
+fuseWith :: forall f g h m a. (Functor f, Functor g, Functor h, MonadRec m, MonadPar m) => (forall d. forall b c. (b -> c -> d) -> f b -> g c -> h d) -> Co f m a -> Co g m a -> Co h m a
 ```
 
 Fuse two `Co`routines.
@@ -196,7 +196,7 @@ Cotransform input values.
 #### `transformCoTransformL`
 
 ``` purescript
-transformCoTransformL :: forall i1 i2 o m a. MonadRec m => Transformer i1 i2 m a -> CoTransformer i2 o m a -> CoTransformer i1 o m a
+transformCoTransformL :: forall i1 i2 o m a. (MonadRec m, MonadPar m) => Transformer i1 i2 m a -> CoTransformer i2 o m a -> CoTransformer i1 o m a
 ```
 
 Transform a `CoTransformer` on the left.
@@ -204,7 +204,7 @@ Transform a `CoTransformer` on the left.
 #### `transformCoTransformR`
 
 ``` purescript
-transformCoTransformR :: forall i o1 o2 m a. MonadRec m => CoTransformer i o1 m a -> Transformer o1 o2 m a -> CoTransformer i o2 m a
+transformCoTransformR :: forall i o1 o2 m a. (MonadRec m, MonadPar m) => CoTransformer i o1 m a -> Transformer o1 o2 m a -> CoTransformer i o2 m a
 ```
 
 Transform a `CoTransformer` on the right.
@@ -212,7 +212,7 @@ Transform a `CoTransformer` on the right.
 #### `fuseCoTransform`
 
 ``` purescript
-fuseCoTransform :: forall i o m a. MonadRec m => Transformer i o m a -> CoTransformer o i m a -> Process m a
+fuseCoTransform :: forall i o m a. (MonadRec m, MonadPar m) => Transformer i o m a -> CoTransformer o i m a -> Process m a
 ```
 
 Fuse a transformer and a cotransformer.
@@ -220,7 +220,7 @@ Fuse a transformer and a cotransformer.
 #### `connect`
 
 ``` purescript
-connect :: forall o m a. MonadRec m => Producer o m a -> Consumer o m a -> Process m a
+connect :: forall o m a. (MonadRec m, MonadPar m) => Producer o m a -> Consumer o m a -> Process m a
 ```
 
 Connect a producer and a consumer.
@@ -234,7 +234,7 @@ infixr 2 connect as $$
 #### `transformProducer`
 
 ``` purescript
-transformProducer :: forall i o m a. MonadRec m => Producer i m a -> Transformer i o m a -> Producer o m a
+transformProducer :: forall i o m a. (MonadRec m, MonadPar m) => Producer i m a -> Transformer i o m a -> Producer o m a
 ```
 
 Transform a producer.
@@ -248,7 +248,7 @@ infixr 2 transformProducer as $~
 #### `transformConsumer`
 
 ``` purescript
-transformConsumer :: forall i o m a. MonadRec m => Transformer i o m a -> Consumer o m a -> Consumer i m a
+transformConsumer :: forall i o m a. (MonadRec m, MonadPar m) => Transformer i o m a -> Consumer o m a -> Consumer i m a
 ```
 
 Transform a consumer.
@@ -262,7 +262,7 @@ infixr 2 transformConsumer as ~$
 #### `composeTransformers`
 
 ``` purescript
-composeTransformers :: forall i j k m a. MonadRec m => Transformer i j m a -> Transformer j k m a -> Transformer i k m a
+composeTransformers :: forall i j k m a. (MonadRec m, MonadPar m) => Transformer i j m a -> Transformer j k m a -> Transformer i k m a
 ```
 
 Compose transformers
@@ -276,7 +276,7 @@ infixr 2 composeTransformers as ~~
 #### `composeCoTransformers`
 
 ``` purescript
-composeCoTransformers :: forall i j k m a. MonadRec m => CoTransformer i j m a -> CoTransformer j k m a -> CoTransformer i k m a
+composeCoTransformers :: forall i j k m a. (MonadRec m, MonadPar m) => CoTransformer i j m a -> CoTransformer j k m a -> CoTransformer i k m a
 ```
 
 Compose cotransformers
@@ -284,7 +284,7 @@ Compose cotransformers
 #### `joinProducers`
 
 ``` purescript
-joinProducers :: forall o1 o2 m a. MonadRec m => Producer o1 m a -> Producer o2 m a -> Producer (Tuple o1 o2) m a
+joinProducers :: forall o1 o2 m a. (MonadRec m, MonadPar m) => Producer o1 m a -> Producer o2 m a -> Producer (Tuple o1 o2) m a
 ```
 
 Run two producers together.
@@ -298,7 +298,7 @@ infixr 3 joinProducers as /\
 #### `joinConsumers`
 
 ``` purescript
-joinConsumers :: forall i1 i2 m a. MonadRec m => Consumer i1 m a -> Consumer i2 m a -> Consumer (Tuple i1 i2) m a
+joinConsumers :: forall i1 i2 m a. (MonadRec m, MonadPar m) => Consumer i1 m a -> Consumer i2 m a -> Consumer (Tuple i1 i2) m a
 ```
 
 Run two consumers together

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,38 +3,45 @@ module Test.Main where
 import Prelude
 
 import Control.Coroutine (Transformer, CoTransformer, Consumer, Producer,
-                          runProcess, transform, fuseCoTransform, cotransform, consumer, emit,
-                          (~$), ($$), (/\))
+                          runProcess, transform, fuseCoTransform, cotransform,
+                          await, emit, (~$), ($~), ($$), (/\))
+import Control.Monad.Aff (Aff, later', launchAff)
 import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Rec.Class (forever)
 import Control.Monad.Trans (lift)
 import Data.Functor (($>))
 import Data.Maybe (Maybe(..))
 
-nats :: forall m. Monad m => Producer Int m Unit
+nats :: forall eff. Producer Int (Aff eff) Unit
 nats = go 0
   where
   go i = do
     emit i
+    lift (later' 10 (pure unit)) -- 10ms delay
     go (i + 1)
 
-printer :: forall eff. Consumer String (Eff (console :: CONSOLE | eff)) Unit
-printer = consumer \s -> log s $> Nothing
+printer :: forall eff. Consumer String (Aff (console :: CONSOLE | eff)) Unit
+printer = forever do
+  s <- await
+  lift (liftEff (log s))
+  pure Nothing
 
 showing :: forall a m. (Show a, Monad m) => Transformer a String m Unit
 showing = forever (transform show)
 
-coshowing :: forall eff. CoTransformer String Int (Eff (console :: CONSOLE | eff)) Unit
+coshowing :: forall eff. CoTransformer String Int (Aff (console :: CONSOLE | eff)) Unit
 coshowing = go 0
   where
   go i = do
     o <- cotransform i
-    lift (log o)
+    lift (liftEff (log o))
     go (i + 1)
 
-main :: forall eff. Eff (console :: CONSOLE | eff) Unit
-main =
-  runProcess (showing `fuseCoTransform` coshowing)
-  -- runProcess (nats $~ showing $$ printer)
-  -- runProcess (nats /\ nats $$ showing ~$ printer)
+main :: forall eff. Eff (err :: EXCEPTION, console :: CONSOLE | eff) Unit
+main = void $ launchAff $
+  -- runProcess (showing `fuseCoTransform` coshowing)))
+  -- runProcess ((nats $~ showing) $$ printer)
+  runProcess (nats /\ nats $$ showing ~$ printer)


### PR DESCRIPTION
@garyb Could you please review this?

It's needed to fix something in Thermite, but I think it's a better approach generally. I know you use this in Halogen now too.

Obviously, it's a breaking change. It also ties us to `MonadPar`, which basically means `Aff`, but I think that's fine, since that's the main use case anyway, and at least it's suitably abstracted.
