### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#38 by @thomashoneyman)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-coroutines/releases/tag/v6.0.0) - 2021-02-26
 

--- a/src/Control/Coroutine.purs
+++ b/src/Control/Coroutine.purs
@@ -10,20 +10,37 @@ module Control.Coroutine
   , runProcess
   , fuseWith
   , fuseWithL
-  , Emit(..), Producer, emit, producer
-  , Await(..), Consumer, await, consumer
-  , Transform(..), Transformer, transform
-  , CoTransform(..), CoTransformer, cotransform
-  , connect, ($$), pullFrom
-  , transformProducer, ($~)
-  , transformConsumer, (~$)
-  , composeTransformers, (~~)
+  , Emit(..)
+  , Producer
+  , emit
+  , producer
+  , Await(..)
+  , Consumer
+  , await
+  , consumer
+  , Transform(..)
+  , Transformer
+  , transform
+  , CoTransform(..)
+  , CoTransformer
+  , cotransform
+  , connect
+  , ($$)
+  , pullFrom
+  , transformProducer
+  , ($~)
+  , transformConsumer
+  , (~$)
+  , composeTransformers
+  , (~~)
   , composeCoTransformers
   , fuseCoTransform
   , transformCoTransformL
   , transformCoTransformR
-  , joinProducers, (/\)
-  , joinConsumers, (\/)
+  , joinProducers
+  , (/\)
+  , joinConsumers
+  , (\/)
   ) where
 
 import Prelude
@@ -74,8 +91,9 @@ fuseWith zap fs gs = freeT \_ -> go (Tuple fs gs)
   go :: Tuple (Co f m a) (Co g m a) -> m (Either a (h (Co h m a)))
   go (Tuple fs' gs') = do
     next <- sequential
-              (lift2 (zap Tuple) <$> parallel (resume fs')
-                                 <*> parallel (resume gs'))
+      ( lift2 (zap Tuple) <$> parallel (resume fs')
+          <*> parallel (resume gs')
+      )
     case next of
       Left a -> pure (Left a)
       Right o -> pure (Right (map (\t -> freeT \_ -> go t) o))

--- a/src/Control/Coroutine.purs
+++ b/src/Control/Coroutine.purs
@@ -91,7 +91,8 @@ fuseWith zap fs gs = freeT \_ -> go (Tuple fs gs)
   go :: Tuple (Co f m a) (Co g m a) -> m (Either a (h (Co h m a)))
   go (Tuple fs' gs') = do
     next <- sequential
-      ( lift2 (zap Tuple) <$> parallel (resume fs')
+      ( lift2 (zap Tuple)
+          <$> parallel (resume fs')
           <*> parallel (resume gs')
       )
     case next of


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
